### PR TITLE
feat: allow hide line numbers and change left padding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ path = "examples/minimal.rs"
 name = "editor"
 path = "examples/editor.rs"
 [[example]]
+name = "editor_nl"
+path = "examples/editor_nl.rs"
+[[example]]
 name = "half"
 path = "examples/half.rs"
 [[example]]

--- a/examples/editor_nl.rs
+++ b/examples/editor_nl.rs
@@ -1,0 +1,99 @@
+use crossterm::{
+    event::{
+        self, DisableMouseCapture, EnableMouseCapture, 
+        Event, KeyCode, KeyModifiers, KeyEvent
+    },
+    execute,
+    terminal::{
+        EnterAlternateScreen, LeaveAlternateScreen, 
+        disable_raw_mode, enable_raw_mode
+    },
+};
+use ratatui::{Terminal, backend::CrosstermBackend, layout::Position};
+use std::io::stdout;
+use ratatui_code_editor::editor::Editor;
+use ratatui_code_editor::theme::vesper;
+use ratatui_code_editor::utils::get_lang;
+
+fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    
+    let filename = if args.len() > 1 {
+        &args[1]
+    } else {
+        eprintln!("Usage: cargo run --release --example editor_nl <filename>");
+        return Ok(());
+    };
+    
+    let language = get_lang(filename);
+    let content = std::fs::read_to_string(filename)?;
+
+    enable_raw_mode()?;
+    execute!(stdout(), EnterAlternateScreen)?;
+    execute!(stdout(), EnableMouseCapture)?;
+
+    let backend = CrosstermBackend::new(stdout());
+    let mut terminal = Terminal::new(backend)?;
+    
+    let theme = vesper();
+
+    let mut editor = Editor::new(&language, &content, theme)?;
+    let mut editor_area = ratatui::layout::Rect::default(); 
+
+    editor.show_line_numbers(false);
+
+    loop {
+
+        terminal.draw(|f| {
+            let area = f.area();
+            editor_area = area;
+            f.render_widget(&editor, area);
+            
+            let cursor = editor.get_visible_cursor(&area);
+            if let Some((x,y)) = cursor {
+                f.set_cursor_position(Position::new(x, y));
+            }
+        })?;
+
+        if event::poll(std::time::Duration::from_millis(100))? {
+            match event::read()? {
+                Event::Key(key) => {
+                    if key.code == KeyCode::Esc {
+                        break;
+                    } else if is_save_pressed(key) {
+                        let content = editor.get_content();
+                        save_to_file(&content, filename)?;
+                    } else {
+                        editor.input(key, &editor_area)?;
+                    }
+                }
+                Event::Mouse(mouse) => {
+                    editor.mouse(mouse, &editor_area)?;
+                },
+                Event::Resize(_, _) => { }
+                _ => {}
+            }
+        }
+    }
+
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    Ok(())
+}
+
+fn save_to_file(content: &str, path: &str) -> anyhow::Result<()> {
+    use std::io::Write;
+    
+    let mut file = std::fs::File::create(path)?;
+    file.write_all(content.as_bytes())?;
+    Ok(())
+}
+
+fn is_save_pressed(key: KeyEvent) -> bool {
+    key.modifiers.contains(KeyModifiers::CONTROL) &&
+        key.code == KeyCode::Char('s')
+}

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -59,6 +59,12 @@ pub struct Editor {
 
     /// Syntax highlight cache by intervals to speed up rendering
     pub(crate) highlights_cache: RefCell<HightlightCache>,
+
+    /// Controls when to show the line numbers
+    pub(crate) show_line_numbers: bool,
+
+    /// Controls the left padding before writing the code
+    pub(crate) left_code_padding: usize,
 }
 
 impl Editor {
@@ -90,8 +96,21 @@ impl Editor {
             clipboard: None,
             marks: None,
             highlights_cache,
+            show_line_numbers: true,
+            left_code_padding: 2,
         })
     }
+
+    pub(crate) fn get_line_number_width(&self) -> usize {
+        if self.show_line_numbers {
+            let total_lines = self.code.len_lines();
+            let max_line_number = total_lines.max(1);
+            let line_number_digits = max_line_number.to_string().len().max(5);
+            (line_number_digits + self.left_code_padding) as usize
+        } else {
+            self.left_code_padding
+        }
+    } 
 
     pub fn input(
         &mut self, key: KeyEvent, area: &Rect,
@@ -130,10 +149,7 @@ impl Editor {
     pub fn focus(&mut self, area: &Rect) {
         let width = area.width as usize;
         let height = area.height as usize;
-        let total_lines = self.code.len_lines();
-        let max_line_number = total_lines.max(1);
-        let line_number_digits = max_line_number.to_string().len().max(5);
-        let line_number_width = (line_number_digits + 2) as usize;
+        let line_number_width = self.get_line_number_width();
 
         let line = self.code.char_to_line(self.cursor);
         let col = self.cursor - self.code.line_to_char(line);
@@ -247,10 +263,7 @@ impl Editor {
     fn cursor_from_mouse(
         &self, mouse_x: u16, mouse_y: u16, area: &Rect
     ) -> Option<usize> {
-        let total_lines = self.code.len_lines();
-        let max_line_number = total_lines.max(1);
-        let line_number_digits = max_line_number.to_string().len().max(5);
-        let line_number_width = (line_number_digits + 2) as u16;
+        let line_number_width = self.get_line_number_width() as u16;
     
         if mouse_y < area.top()
             || mouse_y >= area.bottom()
@@ -516,10 +529,7 @@ impl Editor {
     pub fn get_visible_cursor(
         &self, area: &Rect
     ) -> Option<(u16, u16)> {
-        let total_lines = self.code.len_lines();
-        let max_line_number = total_lines.max(1);
-        let line_number_digits = max_line_number.to_string().len().max(5);
-        let line_number_width = line_number_digits + 2;
+        let line_number_width = self.get_line_number_width();
 
         let (cursor_line, cursor_char_col) = self.code.point(self.cursor);
         
@@ -552,5 +562,13 @@ impl Editor {
         }
         
         return None;
+    }
+
+    pub fn show_line_numbers(&mut self, show: bool) {
+        self.show_line_numbers = show
+    }
+
+    pub fn set_left_code_padding(&mut self, char_count: usize) {
+        self.left_code_padding = char_count
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -21,11 +21,12 @@ use crate::code::{
 impl Widget for &Editor {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let code = self.code_ref();
-        let total_lines = code.len_lines();
         let total_chars = code.len_chars();
+
+        let total_lines = code.len_lines();
         let max_line_number = total_lines.max(1);
         let line_number_digits = max_line_number.to_string().len().max(5);
-        let line_number_width = line_number_digits + 2;
+        let line_number_width = self.get_line_number_width();
 
         let mut draw_y = area.top();
         
@@ -35,10 +36,12 @@ impl Widget for &Editor {
         // draw line numbers and text
         for line_idx in self.offset_y..total_lines {
             if draw_y >= area.bottom() { break }
-        
-            let line_number = format!("{:^width$}", line_idx + 1, width = line_number_digits);
-            buf.set_string(area.left(), draw_y, &line_number, line_number_style);
-        
+
+            if self.show_line_numbers {
+                let line_number = format!("{:^width$}", line_idx + 1, width = line_number_digits);
+                buf.set_string(area.left(), draw_y, &line_number, line_number_style);
+            }
+
             let line_len = code.line_len(line_idx);
             let max_x = (area.width as usize).saturating_sub(line_number_width);
         


### PR DESCRIPTION
fixes: #11 

Added a function in editor.rs to calculate the left code padding called  and remove all the unnecessary code with in that function.

Added show_line_numbers and left_code_padding properties for the Editor struct to control when to show the line numbers and the padding left of the code editor

Added and example called editor_nl mirroring editor. to show the no line number configuration

> Also great job, your code is perfectly readable congrats 🎉.